### PR TITLE
jsファイルからturbolinksの記述を削除

### DIFF
--- a/app/assets/javascripts/user-registration.js
+++ b/app/assets/javascripts/user-registration.js
@@ -1,5 +1,4 @@
-$(document).on('turbolinks:load', function() {
-
+$(function(){
   $('.btn-mail').on("click", function() {
     $('section').css('display','none');
     $('.registration').css('display','block');


### PR DESCRIPTION
Gem turbolinksが削除されていたため、jsファイルが反応しなくなったため、記述を削除。